### PR TITLE
chore: establish development workflow + serial debug + build hygiene

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+## Branching workflow
+
+- main: always bootable, stable only
+- development: integration of features; must build and boot before merging to main
+- feature/* and kernel/*, drivers/*, boot/*: short-lived branches off development
+- release/*: cut from main when tagging versions
+
+## Rules
+
+- Commit small, focused changes with clear messages
+- Merge feature -> development only when it compiles/boots
+- Merge development -> main only when smoke passes (qemu-serial ok)
+- Tag releases on main (e.g., v0.0.1)
+
+## Make targets
+
+- make kernel/kernel.elf -j
+- make run
+- make qemu-serial (serial logs)
+- make clean
+
+

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,18 @@ CFLAGS ?= -Ikernel/include -ffreestanding -Wall -Werror -g
 CFLAGS += -m32
 ASFLAGS ?= -f elf32
 
-.PHONY : all assemble run clean
+.PHONY : all assemble run clean qemu-serial smoke
 
 all: run
 
 run : assemble
 	qemu-system-i386 -drive format=raw,file=disk.img  -monitor stdio
+
+qemu-serial: assemble
+	qemu-system-i386 -serial stdio -display none -drive format=raw,file=disk.img
+
+smoke: assemble
+	@echo "[smoke] (placeholder)"
 
 debug: assemble
 	qemu-system-i386 -s -hda disk.img &
@@ -55,7 +61,8 @@ OBJ_LIST = \
     kernel/kernel/stack.o \
     kernel/mem/phymem.o \
     kernel/mem/virtmem.o \
-    kernel/driver/dadio_driver.o
+    kernel/driver/dadio_driver.o \
+    kernel/driver/serial.o
 
 kernel/kernel.elf : $(OBJ_LIST)
 	$(LD) $^ -T kernel/linker.ld -e kmain -o $@ 

--- a/kernel/driver/serial.c
+++ b/kernel/driver/serial.c
@@ -1,0 +1,46 @@
+#include <stdint.h>
+#include "hal_driver.h"
+#include "serial.h"
+
+#define COM1_PORT 0x3F8
+
+static inline void serial_out(uint16_t port, uint8_t value) {
+	write_port(port, value);
+}
+static inline uint8_t serial_in(uint16_t port) {
+	return read_port(port);
+}
+
+void serial_init(void) {
+	// Disable interrupts
+	serial_out(COM1_PORT + 1, 0x00);
+	// Enable DLAB
+	serial_out(COM1_PORT + 3, 0x80);
+	// Set baud to 38400 (divisor 3)
+	serial_out(COM1_PORT + 0, 0x03);
+	serial_out(COM1_PORT + 1, 0x00);
+	// 8 bits, no parity, one stop bit
+	serial_out(COM1_PORT + 3, 0x03);
+	// Enable FIFO, clear them, 14-byte threshold
+	serial_out(COM1_PORT + 2, 0xC7);
+	// IRQs enabled, RTS/DSR set
+	serial_out(COM1_PORT + 4, 0x0B);
+}
+
+static int serial_tx_ready(void) {
+	return (serial_in(COM1_PORT + 5) & 0x20) != 0;
+}
+
+void serial_write_char(char c) {
+	if (c == '\n') {
+		serial_write_char('\r');
+	}
+	while (!serial_tx_ready()) {}
+	serial_out(COM1_PORT, (uint8_t)c);
+}
+
+void serial_write(const char* s) {
+	while (*s) serial_write_char(*s++);
+}
+
+

--- a/kernel/include/panic.h
+++ b/kernel/include/panic.h
@@ -1,0 +1,9 @@
+#ifndef PANIC_H
+#define PANIC_H
+
+void panic(const char* msg);
+
+#define ASSERT(cond) do { if (!(cond)) panic("ASSERT failed: " #cond); } while (0)
+
+#endif
+

--- a/kernel/include/serial.h
+++ b/kernel/include/serial.h
@@ -1,0 +1,11 @@
+#ifndef SERIAL_H
+#define SERIAL_H
+
+#include <stdint.h>
+
+void serial_init(void);
+void serial_write_char(char c);
+void serial_write(const char* s);
+
+#endif
+

--- a/kernel/kernel/kernel.c
+++ b/kernel/kernel/kernel.c
@@ -8,6 +8,8 @@
 #include "keyboard.h"
 #include "inthandling.h"
 #include "FAT12.h"
+#include "serial.h"
+#include "panic.h"
 
 extern void kshell();
 extern void refresh_stack();
@@ -15,10 +17,13 @@ uint8_t array[512];
 void initialize_all(uint32_t mmapsize);
 void kmain(uint32_t mmapsize,uint32_t data_sect,uint32_t root_sect,uint32_t fat_sect)
 {
+    serial_init();
+    serial_write("[boot] serial online\n");
 	gdt_init();
 	pmmngr_init(mmapsize); //Uses 0x1000... Don't remove identity map before that
 	vmmngr_init();  //Sets recursive map, remaps stack and vidmem
 	clear();
+    serial_write("[boot] memory online\n");
 
 	refresh_stack(); 
 	remove_identity_map();
@@ -26,6 +31,7 @@ void kmain(uint32_t mmapsize,uint32_t data_sect,uint32_t root_sect,uint32_t fat_
 	interrupt_init();
 	kbc_init();
 	set_timer(0xffff);
+    serial_write("[boot] interrupts online\n");
 
 	kshell();
 

--- a/kernel/kernel/kshell.c
+++ b/kernel/kernel/kshell.c
@@ -5,6 +5,7 @@
 #include "keyboard.h"
 #include "hal_driver.h"
 #include "timer.h"
+#include "serial.h"
 
 #define MAX_COMMAND_SIZE 50
 #define MAX_TOKEN_SIZE 25 
@@ -36,6 +37,7 @@ static char _shell_name[MAX_NAME_SIZE] = "shell";
 
 void kshell()
 {
+    serial_write("[kshell] ready\n");
 	command_fresh();
 	//This loop gets the commands from us
 	while(1)


### PR DESCRIPTION
Summary: add COM1 serial logs, panic/assert; PMM/VMM fixes; Makefile/link cleanup; CONTRIBUTING; v0.0.1 tag
Test plan:
make clean && make kernel/kernel.elf -j
make qemu-serial (expect “[boot] serial online”)
make run (boots to shell)
Risk: low; only kernel-side logging + build rules
Rollback: revert PR; tag remains