### PR TITLE
feat(exceptions): add minimal CPU exception ISRs and IDT wiring

### DIFF
--- a/kernel/hal/interruptstubs.asm
+++ b/kernel/hal/interruptstubs.asm
@@ -1,3 +1,24 @@
+global isr0
+global isr1
+global isr2
+global isr3
+global isr4
+global isr5
+global isr6
+global isr7
+global isr8
+global isr9
+global isr10
+global isr11
+global isr12
+global isr13
+global isr14
+global isr15
+global isr16
+global isr17
+global isr18
+global isr19
+
 global isr32
 global isr33
 global isr34
@@ -12,12 +33,124 @@ global isr47
 
 
 ;These are C handlers
+extern default_handler
 extern timer_handler
 extern keyboard_handler
 
 
 extern send_EOI_master
 extern send_EOI_slave
+
+; ---------------------------------------------------------------------
+; Minimal exception stubs (0-19) -> call C default_handler
+; ---------------------------------------------------------------------
+isr0:
+	pusha
+	call default_handler
+	popa
+	iret
+isr1:
+	pusha
+	call default_handler
+	popa
+	iret
+isr2:
+	pusha
+	call default_handler
+	popa
+	iret
+isr3:
+	pusha
+	call default_handler
+	popa
+	iret
+isr4:
+	pusha
+	call default_handler
+	popa
+	iret
+isr5:
+	pusha
+	call default_handler
+	popa
+	iret
+isr6:
+	pusha
+	call default_handler
+	popa
+	iret
+isr7:
+	pusha
+	call default_handler
+	popa
+	iret
+isr8:
+	pusha
+	call default_handler
+	popa
+	add esp, 4 ; pop error code
+	iret
+isr9:
+	pusha
+	call default_handler
+	popa
+	iret
+isr10:
+	pusha
+	call default_handler
+	popa
+	add esp, 4 ; pop error code
+	iret
+isr11:
+	pusha
+	call default_handler
+	popa
+	add esp, 4 ; pop error code
+	iret
+isr12:
+	pusha
+	call default_handler
+	popa
+	add esp, 4 ; pop error code
+	iret
+isr13:
+	pusha
+	call default_handler
+	popa
+	add esp, 4 ; pop error code
+	iret
+isr14:
+	pusha
+	call default_handler
+	popa
+	add esp, 4 ; pop error code
+	iret
+isr15:
+	pusha
+	call default_handler
+	popa
+	iret
+isr16:
+	pusha
+	call default_handler
+	popa
+	iret
+isr17:
+	pusha
+	call default_handler
+	popa
+	add esp, 4 ; pop error code
+	iret
+isr18:
+	pusha
+	call default_handler
+	popa
+	iret
+isr19:
+	pusha
+	call default_handler
+	popa
+	iret
 
 isr32:
 	pusha

--- a/kernel/hal/inthandling.c
+++ b/kernel/hal/inthandling.c
@@ -39,6 +39,27 @@ void machine_check_abort (uint32_t cs, uint32_t  eip, uint32_t flags)  ;
 void simd_fpu_fault (uint32_t cs, uint32_t  eip, uint32_t flags)  ;
 
 //Interrupt handler assembly stubs
+void isr0();
+void isr1();
+void isr2();
+void isr3();
+void isr4();
+void isr5();
+void isr6();
+void isr7();
+void isr8();
+void isr9();
+void isr10();
+void isr11();
+void isr12();
+void isr13();
+void isr14();
+void isr15();
+void isr16();
+void isr17();
+void isr18();
+void isr19();
+
 void isr32();
 void isr33();
 void isr34();
@@ -122,25 +143,27 @@ void interrupt_init()
 	install_ir(46,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr46);
 	install_ir(47,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr47);
 
-	//Exceptions - Need to distinguish between error and no error codes
-
-	install_ir(0,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)divide_by_zero_fault);
-	install_ir(1,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)single_step_trap);
-	install_ir(2,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)nmi_trap);
-	install_ir(3,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)breakpoint_trap);
-	install_ir(4,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)overflow_trap);
-	install_ir(5,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)bounds_check_fault);
-	install_ir(6,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)invalid_opcode_fault);
-	install_ir(7,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)no_device_fault);
-	install_ir(8,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)invalid_tss_fault);
-	install_ir(9,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)no_segment_fault);
-	install_ir(10,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)stack_fault);
-	install_ir(11,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)general_protection_fault);
-	install_ir(12,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)page_fault);
-	install_ir(13,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)fpu_fault);
-	install_ir(14,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)alignment_check_fault);
-	install_ir(15,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)machine_check_abort);
-	install_ir(16,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)simd_fpu_fault);
+	// Exceptions 0-19 -> temporary stubs in ASM
+	install_ir(0,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr0);
+	install_ir(1,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr1);
+	install_ir(2,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr2);
+	install_ir(3,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr3);
+	install_ir(4,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr4);
+	install_ir(5,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr5);
+	install_ir(6,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr6);
+	install_ir(7,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr7);
+	install_ir(8,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr8);
+	install_ir(9,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr9);
+	install_ir(10,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr10);
+	install_ir(11,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr11);
+	install_ir(12,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr12);
+	install_ir(13,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr13);
+	install_ir(14,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr14);
+	install_ir(15,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr15);
+	install_ir(16,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr16);
+	install_ir(17,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr17);
+	install_ir(18,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr18);
+	install_ir(19,IDT_DESC_BIT32|IDT_DESC_PRESENT,0x08,(uint32_t*)isr19);
 
 	init_pic();
 	install_idt(& _idtr);


### PR DESCRIPTION
Summary:
Add ASM stubs for CPU exceptions 0–19.
Wire IDT entries 0–19 to the new stubs.
Handle error-code exceptions by adjusting the stack before iret.
Test plan:
make clean && make kernel/kernel.elf -j
make qemu-serial (expect “[boot] serial online” and “[boot] interrupts online”)
Optionally force an exception (e.g., divide-by-zero) to see default handler print and halt
Risk: low; isolated to interrupt/IDT setup
Rollback: revert PR (no data/state impact)